### PR TITLE
don't return error on empty List result

### DIFF
--- a/memory/storage.go
+++ b/memory/storage.go
@@ -142,10 +142,6 @@ func (s *Storage) List(ctx context.Context, key string) ([]string, error) {
 		list = append(list, k[i+1:])
 	}
 
-	if len(list) == 0 {
-		return nil, microerror.Maskf(microstorage.NotFoundError, key)
-	}
-
 	return list, nil
 }
 

--- a/storagetest/storagetest.go
+++ b/storagetest/storagetest.go
@@ -276,9 +276,9 @@ func testListInvalid(t *testing.T, storage microstorage.Storage) {
 		// - /testListInvalid-key-XXXX/two
 		//
 		// Listing /testListInvalid-key should fail.
-		_, err = storage.List(ctx, baseKey)
-		assert.Error(t, err, "%s: key=%s", name, baseKey)
-		assert.True(t, microstorage.IsNotFound(err), "%s: key=%s expected IsNotFoundError", name, baseKey)
+		list, err := storage.List(ctx, baseKey)
+		assert.NoError(t, err, "%s: key=%s", name, baseKey)
+		assert.Empty(t, list, "%s: key=%s", name, baseKey)
 	}
 }
 


### PR DESCRIPTION
Implementations looked strange, and wasn't intuitive. Also returning
`isNotFound` error for `/` key looks strange. Also every using code
should be prepared for receiving empty result from the List call anyway.

### TODO

- [ ] conform tprstorage
- [ ] conform etcdstorage