### PR TITLE
list all (under '/') keys consistently

### DIFF
--- a/memory/storage.go
+++ b/memory/storage.go
@@ -116,7 +116,8 @@ func (s *Storage) List(ctx context.Context, key string) ([]string, error) {
 	if key == "/" {
 		var list []string
 		for k, _ := range s.data {
-			list = append(list, k)
+			// append a key without leading '/'.
+			list = append(list, k[1:])
 		}
 		return list, nil
 	}

--- a/storagetest/storagetest.go
+++ b/storagetest/storagetest.go
@@ -242,9 +242,9 @@ func testListNested(t *testing.T, storage microstorage.Storage) {
 		keyAll := "/"
 		keys, err := storage.List(ctx, keyAll)
 		assert.NoError(t, err, "%s: key=%s", name, key0)
-		assert.Contains(t, keys, sanitize(key1), "%s: key=%s", name, keyAll)
-		assert.Contains(t, keys, sanitize(key2), "%s: key=%s", name, keyAll)
-		assert.Contains(t, keys, sanitize(key3), "%s: key=%s", name, keyAll)
+		assert.Contains(t, keys, sanitize(key1)[1:], "%s: key=%s", name, keyAll)
+		assert.Contains(t, keys, sanitize(key2)[1:], "%s: key=%s", name, keyAll)
+		assert.Contains(t, keys, sanitize(key3)[1:], "%s: key=%s", name, keyAll)
 	}
 }
 


### PR DESCRIPTION
I discovered this during implementing prefix in etcdstorage