### PR TITLE
prepare storage interface for optimizations

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -40,38 +40,36 @@ func (m *Migrator) Migrate(ctx context.Context, dst, src microstorage.Storage) e
 	var err error
 
 	m.logger.Log("debug", "listing all keys")
-	keys, err := src.List(ctx, "/")
-	if microstorage.IsNotFound(err) {
-		m.logger.Log("debug", "src sotrage is empty")
-		return nil
-	} else if err != nil {
+	srcKVs, err := src.List(ctx, "/")
+	if err != nil {
 		return microerror.Maskf(err, "src storage: listing key=/")
 	}
-
-	m.logger.Log("debug", fmt.Sprintf("transfering %d entries", len(keys)))
-	var migrated int
-	for _, key := range keys {
-		v, err := src.Search(ctx, key)
-		if err != nil {
-			return microerror.Maskf(err, "src storage: getting key=%s", key)
-		}
-
-		exists, err := dst.Exists(ctx, key)
-		if err != nil {
-			return microerror.Maskf(err, "dst storage: checking key=%s", key)
-		}
-
-		if exists {
-			continue
-		}
-
-		err = dst.Put(ctx, key, v)
-		if err != nil {
-			return microerror.Maskf(err, "dst storage: putting key=%s", key)
-		}
-		migrated++
+	dstKVs, err := dst.List(ctx, "/")
+	if err != nil {
+		return microerror.Maskf(err, "dst storage: listing key=/")
 	}
 
-	m.logger.Log("info", fmt.Sprintf("migrated %d/%d remaining entries", migrated, len(keys)))
+	var unmigrated []microstorage.KV
+	{
+		existingKeys := map[string]bool{}
+		for _, kv := range dstKVs {
+			existingKeys[kv.Key] = true
+		}
+
+		for _, kv := range srcKVs {
+			if existingKeys[kv.Key] {
+				continue
+			}
+			unmigrated = append(unmigrated, kv)
+		}
+	}
+
+	m.logger.Log("debug", fmt.Sprintf("migrating %d/%d entries", len(unmigrated), len(srcKVs)))
+	err = dst.Put(ctx, unmigrated...)
+	if err != nil {
+		return microerror.Maskf(err, "src storage: putting %d entries", len(unmigrated))
+	}
+
+	m.logger.Log("info", fmt.Sprintf("migrated %d/%d entries", len(unmigrated), len(srcKVs)))
 	return nil
 }

--- a/storage.go
+++ b/storage.go
@@ -4,37 +4,39 @@ import (
 	"context"
 )
 
-// Storage represents the abstraction for underlying storage backends. A storage
-// implementation does not care about specific data types. All the
-// storage cares about are key-value pairs. Code making use of the storage
-// have to take care about specific types they care about them self.
+// KV is a key-value pair.
+type KV struct {
+	// Key should take a format of path separated by slashes "/". E.g.
+	// "/a/b/c". Storage implementations should validate the key before
+	// storing them. Key sanitized before inserting to the storage. I.e.
+	// leading slash can be added and trailing slash can be removed. E.g.
+	// "/a/b/c", "a/b/c/", "a/b/c/", and "/a/b/c/" represent the same key.
+	Key string
+	// Val is an arbitrary value stored under the Key.
+	Val string
+}
+
+func NewKV(key, val string) KV {
+	return KV{
+		Key: key,
+		Val: val,
+	}
+}
+
+// Storage represents the abstraction for underlying storage backends.
 type Storage interface {
-	// Create is deprecated in favour of Put. Its semantics is unspecified
-	// when the value of the key does not exist.
-	//
-	// Create stores the given value under the given key. Keys and values
-	// might have specific schemes depending on the specific storage
-	// implementation.  E.g. an etcd storage implementation will allow keys
-	// to be defined as paths: path/to/key. Values might be JSON strings in
-	// case the storage implementation wants to store its data as JSON
-	// strings.
-	Create(ctx context.Context, key, value string) error
 	// Put stores the given value under the given key. If the value
-	// under the key already exists Put overrides it. Keys and values might
-	// have specific schemes depending on the specific storage
-	// implementation.  E.g. an etcd storage implementation will allow keys
-	// to be defined as paths: path/to/key. Values might be JSON strings in
-	// case the storage implementation wants to store its data as JSON
-	// strings.
-	Put(ctx context.Context, key, value string) error
+	// under the key already exists Put overrides it.
+	Put(ctx context.Context, kvs ...KV) error
 	// Delete removes the value stored under the given key.
 	Delete(ctx context.Context, key string) error
 	// Exists checks if a value under the given key exists or not.
 	Exists(ctx context.Context, key string) (bool, error)
-	// List does a lookup for all keys stored under the key, and returns the
-	// relative key path, if any.
+	// List does a lookup for all key-values stored under the key, and
+	// returns the relative key path, if any.
 	// E.g: listing /foo/, with the key /foo/bar, returns bar.
-	List(ctx context.Context, key string) ([]string, error)
-	// Search does a lookup for the value stored under key and returns it, if any.
-	Search(ctx context.Context, key string) (string, error)
+	List(ctx context.Context, key string) ([]KV, error)
+	// Search does a lookup for the value stored under key and returns it,
+	// if any.
+	Search(ctx context.Context, key string) (KV, error)
 }

--- a/storagetest/storagetest.go
+++ b/storagetest/storagetest.go
@@ -18,6 +18,7 @@ import (
 func Test(t *testing.T, storage microstorage.Storage) {
 	testBasicCRUD(t, storage)
 	testPutIdempotent(t, storage)
+	testPutMultiple(t, storage)
 	testDeleteNotExisting(t, storage)
 	testInvalidKey(t, storage)
 	testList(t, storage)
@@ -36,35 +37,36 @@ func testBasicCRUD(t *testing.T, storage microstorage.Storage) {
 	)
 
 	for _, key := range validKeyVariations(baseKey) {
-		ok, err := storage.Exists(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.False(t, ok, "%s: key=%s", name, key)
+		kv := microstorage.NewKV(key, value)
 
-		v, err := storage.Search(ctx, key)
-		require.NotNil(t, err, "%s: key=%s", name, key)
-		require.True(t, microstorage.IsNotFound(err), "%s: key=%s expected IsNotFoundError", name, key)
+		ok, err := storage.Exists(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.False(t, ok, "%s: kv=%#v", name, kv)
 
-		err = storage.Put(ctx, key, value)
-		require.NoError(t, err, "%s: key=%s", name, key)
+		_, err = storage.Search(ctx, kv.Key)
+		require.NotNil(t, err, "%s: kv=%#v", name, kv)
+		require.True(t, microstorage.IsNotFound(err), "%s: key=%s expected IsNotFoundError", name, kv.Key)
 
-		ok, err = storage.Exists(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.True(t, ok, "%s: key=%s", name, key)
+		err = storage.Put(ctx, kv)
 
-		v, err = storage.Search(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.Equal(t, value, v, "%s: key=%s", name, key)
+		ok, err = storage.Exists(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.True(t, ok, "%s: kv=%#v", name, kv)
+
+		gotKV, err := storage.Search(ctx, key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.Equal(t, sanitize(kv), gotKV, "%s: kv=%#v", name, kv)
 
 		err = storage.Delete(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
 
 		ok, err = storage.Exists(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.False(t, ok, "%s: key=%s", name, key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.False(t, ok, "%s: kv=%#v", name, kv)
 
-		v, err = storage.Search(ctx, key)
-		require.NotNil(t, err, "%s: key=%s", name, key)
-		require.True(t, microstorage.IsNotFound(err), "%s: key=%s expected IsNotFoundError", name, key)
+		_, err = storage.Search(ctx, key)
+		require.NotNil(t, err, "%s: kv=%#v", name, kv)
+		require.True(t, microstorage.IsNotFound(err), "%s: key=%s expected IsNotFoundError", name, kv.Key)
 	}
 }
 
@@ -80,36 +82,80 @@ func testPutIdempotent(t *testing.T, storage microstorage.Storage) {
 	)
 
 	for _, key := range validKeyVariations(baseKey) {
-		ok, err := storage.Exists(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.False(t, ok, "%s: key=%s", name, key)
+		kv := microstorage.NewKV(key, value)
+
+		ok, err := storage.Exists(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.False(t, ok, "%s: kv=%#v", name, kv)
 
 		// First Put call.
 
-		err = storage.Put(ctx, key, value)
-		require.NoError(t, err, "%s: key=%s", name, key)
+		err = storage.Put(ctx, microstorage.NewKV(kv.Key, value))
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
 
-		v, err := storage.Search(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.Equal(t, value, v, "%s: key=%s", name, key)
+		gotKV, err := storage.Search(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.Equal(t, sanitize(kv), gotKV, "%s: kv=%#v", name, kv)
 
 		// Second Put call with the same value.
 
-		err = storage.Put(ctx, key, value)
-		require.NoError(t, err, "%s: key=%s", name, key)
+		err = storage.Put(ctx, kv)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
 
-		v, err = storage.Search(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.Equal(t, value, v, "%s: key=%s", name, key)
+		gotKV, err = storage.Search(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.Equal(t, sanitize(kv), gotKV, "%s: kv=%#v", name, kv)
 
 		// Third Put call with overriding value.
 
-		err = storage.Put(ctx, key, overridenValue)
-		require.NoError(t, err, "%s: key=%s", name, key)
+		overridenKV := microstorage.NewKV(kv.Key, overridenValue)
+		err = storage.Put(ctx, overridenKV)
+		require.NoError(t, err, "%s: kv=%#v", name, overridenKV)
 
-		v, err = storage.Search(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.Equal(t, overridenValue, v, "%s: key=%s", name, key)
+		gotKV, err = storage.Search(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, overridenKV)
+		require.Equal(t, sanitize(overridenKV), gotKV, "%s: kv=%#s", name, overridenKV)
+	}
+}
+
+func testPutMultiple(t *testing.T, storage microstorage.Storage) {
+	var (
+		name = "testPutMultiple"
+
+		ctx = context.TODO()
+
+		kvs = []microstorage.KV{
+			{
+				Key: name + "-key-1",
+				Val: name + "-value-1",
+			},
+			{
+				Key: name + "-key-1/nested/key",
+				Val: name + "-value-1",
+			},
+			{
+				Key: name + "-key-2",
+				Val: name + "-value-2",
+			},
+			{
+				Key: name + "-key-3",
+				Val: name + "-value-3",
+			},
+		}
+	)
+
+	for _, kv := range kvs {
+		ok, err := storage.Exists(ctx, kv.Key)
+		require.NoError(t, err, "%s: key=%s", name, kv.Key)
+		require.False(t, ok, "%s: key=%s", name, kv.Key)
+	}
+
+	storage.Put(ctx, kvs...)
+
+	for _, kv := range kvs {
+		gotKV, err := storage.Search(ctx, kv.Key)
+		require.NoError(t, err, "%s: key=%s", name, kv.Key)
+		require.Equal(t, kv, gotKV, "%s: key=%s", name, kv.Key)
 	}
 }
 
@@ -153,11 +199,7 @@ func testInvalidKey(t *testing.T, storage microstorage.Storage) {
 	}
 
 	for _, key := range keys {
-		err := storage.Create(ctx, key, value)
-		assert.NotNil(t, err, "%s key=%s", name, key)
-		assert.True(t, microstorage.IsInvalidKey(err), "%s: expected InvalidKeyError for key=%s", name, key)
-
-		err = storage.Put(ctx, key, value)
+		err := storage.Put(ctx, microstorage.NewKV(key, value))
 		assert.NotNil(t, err, "%s key=%s", name, key)
 		assert.True(t, microstorage.IsInvalidKey(err), "%s: expected InvalidKeyError for key=%s", name, key)
 
@@ -196,22 +238,22 @@ func testList(t *testing.T, storage microstorage.Storage) {
 		key1 := path.Join(key0, "one")
 		key2 := path.Join(key0, "two")
 
-		err := storage.Create(ctx, key1, value)
+		err := storage.Put(ctx, microstorage.NewKV(key1, value))
 		assert.Nil(t, err, "%s: key=%s", name, key1)
 
-		err = storage.Create(ctx, key2, value)
+		err = storage.Put(ctx, microstorage.NewKV(key2, value))
 		assert.Nil(t, err, "%s: key=%s", name, key2)
 
-		wkeys := []string{
-			"one",
-			"two",
+		kvs := []microstorage.KV{
+			microstorage.NewKV("one", value),
+			microstorage.NewKV("two", value),
 		}
-		sort.Strings(wkeys)
+		sort.Sort(kvSlice(kvs))
 
-		keys, err := storage.List(ctx, key0)
+		gotKVs, err := storage.List(ctx, key0)
 		assert.NoError(t, err, "%s: key=%s", name, key0)
-		sort.Strings(keys)
-		assert.Equal(t, wkeys, keys, "%s: key=%s", name, key0)
+		sort.Sort(kvSlice(gotKVs))
+		assert.Equal(t, kvs, gotKVs, "%s: key=%s", name, key0)
 	}
 }
 
@@ -225,26 +267,30 @@ func testListNested(t *testing.T, storage microstorage.Storage) {
 		value   = name + "-value"
 	)
 
-	for _, key0 := range validKeyVariations(baseKey) {
-		key1 := path.Join(key0, "nested/one")
-		key2 := path.Join(key0, "nested/two")
-		key3 := path.Join(key0, "extremaly/nested/three")
+	for _, key := range validKeyVariations(baseKey) {
+		kvs := []microstorage.KV{
+			microstorage.NewKV(path.Join(key, "nested/one"), value),
+			microstorage.NewKV(path.Join(key, "nested/two"), value),
+			microstorage.NewKV(path.Join(key, "extremaly/nested/three"), value),
+		}
 
-		err := storage.Create(ctx, key1, value)
-		assert.Nil(t, err, "%s: key=%s", name, key1)
-
-		err = storage.Create(ctx, key2, value)
-		assert.Nil(t, err, "%s: key=%s", name, key2)
-
-		err = storage.Create(ctx, key3, value)
-		assert.Nil(t, err, "%s: key=%s", name, key3)
+		for _, kv := range kvs {
+			err := storage.Put(ctx, kv)
+			assert.Nil(t, err, "%s: kv=%#v", name, kv)
+		}
 
 		keyAll := "/"
-		keys, err := storage.List(ctx, keyAll)
-		assert.NoError(t, err, "%s: key=%s", name, key0)
-		assert.Contains(t, keys, sanitize(key1)[1:], "%s: key=%s", name, keyAll)
-		assert.Contains(t, keys, sanitize(key2)[1:], "%s: key=%s", name, keyAll)
-		assert.Contains(t, keys, sanitize(key3)[1:], "%s: key=%s", name, keyAll)
+		gotKVs, err := storage.List(ctx, keyAll)
+		assert.NoError(t, err, "%s: key=%#v", name, keyAll)
+
+		for _, kv := range kvs {
+			kv = sanitize(kv)
+			// Skip leading slash. This is like in file system
+			// root. When create `touch /file`, listing it `ls /`
+			// outputs `file`.
+			kv.Key = kv.Key[1:]
+			assert.Contains(t, gotKVs, kv, "%s: key=%#v", name, keyAll)
+		}
 	}
 }
 
@@ -262,10 +308,10 @@ func testListInvalid(t *testing.T, storage microstorage.Storage) {
 		key1 := path.Join(key0, "one")
 		key2 := path.Join(key0, "two")
 
-		err := storage.Create(ctx, key1, value)
+		err := storage.Put(ctx, microstorage.NewKV(key1, value))
 		assert.Nil(t, err, "%s: key=%s", name, key1)
 
-		err = storage.Create(ctx, key2, value)
+		err = storage.Put(ctx, microstorage.NewKV(key2, value))
 		assert.Nil(t, err, "%s: key=%s", name, key2)
 
 		// baseKey is key0 prefix.
@@ -304,10 +350,17 @@ func validKeyVariations(key string) []string {
 	}
 }
 
-func sanitize(key string) string {
-	k, err := microstorage.SanitizeKey(key)
+func sanitize(kv microstorage.KV) microstorage.KV {
+	k, err := microstorage.SanitizeKey(kv.Key)
 	if err != nil {
 		panic(err)
 	}
-	return k
+	kv.Key = k
+	return kv
 }
+
+type kvSlice []microstorage.KV
+
+func (p kvSlice) Len() int           { return len(p) }
+func (p kvSlice) Less(i, j int) bool { return p[i].Key < p[j].Key }
+func (p kvSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }


### PR DESCRIPTION
Theres is bunch on interface changes which allow to:

- Do further storage implementation optimizations.
- Make migration optimizations possible.
- Make Storage usage more efficient in services like userd.

Changes:

- Removed Created. It shouldn't be a lot of a hassle to migrate to Put
  now.
- Introduced KV struct.
- Put takes multiple KVs. This gives some space for optimizations.
  Especially when during migration.
- List returns KVs instead of keys-only. This prevents from doing another
  call when it's necessary to also know key value. Useful in userd for
  example. Also useful in data migration optimization.
- Search returns KV to be on par with List.