### PR TITLE
remove Create from the interface

### DIFF
--- a/memory/storage.go
+++ b/memory/storage.go
@@ -38,21 +38,6 @@ type Storage struct {
 	mutex sync.Mutex
 }
 
-func (s *Storage) Create(ctx context.Context, key, value string) error {
-	var err error
-
-	key, err = microstorage.SanitizeKey(key)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = s.Put(ctx, key, value)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	return nil
-}
-
 func (s *Storage) Put(ctx context.Context, key, value string) error {
 	var err error
 

--- a/retrystorage/storage.go
+++ b/retrystorage/storage.go
@@ -91,22 +91,6 @@ func New(config Config) (*Storage, error) {
 	return s, nil
 }
 
-func (s *Storage) Create(ctx context.Context, key, value string) error {
-	b := s.newBackOffFunc()
-	op := func() error {
-		err := s.underlying.Create(ctx, key, value)
-		if microstorage.IsInvalidKey(err) || microstorage.IsNotFound(err) {
-			return backoff.Permanent(err)
-		}
-		return err
-	}
-	notify := func(err error, delay time.Duration) {
-		s.logger.Log("warning", "retrying", "op", "create", "key", key, "delay", delay, "err", fmt.Sprintf("%#v", err))
-	}
-	err := backoff.RetryNotify(op, b, notify)
-	return microerror.Mask(err)
-}
-
 func (s *Storage) Put(ctx context.Context, key, value string) error {
 	b := s.newBackOffFunc()
 	op := func() error {

--- a/storage.go
+++ b/storage.go
@@ -9,7 +9,7 @@ import (
 // storage cares about are key-value pairs. Code making use of the storage
 // have to take care about specific types they care about them self.
 type Storage interface {
-	// Put stores the given value under the given key.
+	// Put stores the given value under the given key. If the value
 	// under the key already exists Put overrides it. Keys and values might
 	// have specific schemes depending on the specific storage
 	// implementation.  E.g. an etcd storage implementation will allow keys

--- a/storage.go
+++ b/storage.go
@@ -9,17 +9,7 @@ import (
 // storage cares about are key-value pairs. Code making use of the storage
 // have to take care about specific types they care about them self.
 type Storage interface {
-	// Create is deprecated in favour of Put. Its semantics is unspecified
-	// when the value of the key does not exist.
-	//
-	// Create stores the given value under the given key. Keys and values
-	// might have specific schemes depending on the specific storage
-	// implementation.  E.g. an etcd storage implementation will allow keys
-	// to be defined as paths: path/to/key. Values might be JSON strings in
-	// case the storage implementation wants to store its data as JSON
-	// strings.
-	Create(ctx context.Context, key, value string) error
-	// Put stores the given value under the given key. If the value
+	// Put stores the given value under the given key.
 	// under the key already exists Put overrides it. Keys and values might
 	// have specific schemes depending on the specific storage
 	// implementation.  E.g. an etcd storage implementation will allow keys

--- a/storagetest/storagetest.go
+++ b/storagetest/storagetest.go
@@ -153,7 +153,7 @@ func testInvalidKey(t *testing.T, storage microstorage.Storage) {
 	}
 
 	for _, key := range keys {
-		err := storage.Create(ctx, key, value)
+		err := storage.Put(ctx, key, value)
 		assert.NotNil(t, err, "%s key=%s", name, key)
 		assert.True(t, microstorage.IsInvalidKey(err), "%s: expected InvalidKeyError for key=%s", name, key)
 
@@ -196,10 +196,10 @@ func testList(t *testing.T, storage microstorage.Storage) {
 		key1 := path.Join(key0, "one")
 		key2 := path.Join(key0, "two")
 
-		err := storage.Create(ctx, key1, value)
+		err := storage.Put(ctx, key1, value)
 		assert.Nil(t, err, "%s: key=%s", name, key1)
 
-		err = storage.Create(ctx, key2, value)
+		err = storage.Put(ctx, key2, value)
 		assert.Nil(t, err, "%s: key=%s", name, key2)
 
 		wkeys := []string{
@@ -230,13 +230,13 @@ func testListNested(t *testing.T, storage microstorage.Storage) {
 		key2 := path.Join(key0, "nested/two")
 		key3 := path.Join(key0, "extremaly/nested/three")
 
-		err := storage.Create(ctx, key1, value)
+		err := storage.Put(ctx, key1, value)
 		assert.Nil(t, err, "%s: key=%s", name, key1)
 
-		err = storage.Create(ctx, key2, value)
+		err = storage.Put(ctx, key2, value)
 		assert.Nil(t, err, "%s: key=%s", name, key2)
 
-		err = storage.Create(ctx, key3, value)
+		err = storage.Put(ctx, key3, value)
 		assert.Nil(t, err, "%s: key=%s", name, key3)
 
 		keyAll := "/"
@@ -262,10 +262,10 @@ func testListInvalid(t *testing.T, storage microstorage.Storage) {
 		key1 := path.Join(key0, "one")
 		key2 := path.Join(key0, "two")
 
-		err := storage.Create(ctx, key1, value)
+		err := storage.Put(ctx, key1, value)
 		assert.Nil(t, err, "%s: key=%s", name, key1)
 
-		err = storage.Create(ctx, key2, value)
+		err = storage.Put(ctx, key2, value)
 		assert.Nil(t, err, "%s: key=%s", name, key2)
 
 		// baseKey is key0 prefix.


### PR DESCRIPTION
It adds only confusion. It shouldn't be a hassle to migrate given that
we don't use storage in multiple places.