### PR TITLE
introduce KV struct

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -39,8 +39,8 @@ func New(config Config) (*Migrator, error) {
 func (m *Migrator) Migrate(ctx context.Context, dst, src microstorage.Storage) error {
 	var err error
 
-	m.logger.Log("debug", "listing all keys")
-	keys, err := src.List(ctx, "/")
+	m.logger.Log("debug", "listing all KVs")
+	kvs, err := src.List(ctx, "/")
 	if microstorage.IsNotFound(err) {
 		m.logger.Log("debug", "src sotrage is empty")
 		return nil
@@ -48,30 +48,25 @@ func (m *Migrator) Migrate(ctx context.Context, dst, src microstorage.Storage) e
 		return microerror.Maskf(err, "src storage: listing key=/")
 	}
 
-	m.logger.Log("debug", fmt.Sprintf("transfering %d entries", len(keys)))
+	m.logger.Log("debug", fmt.Sprintf("transfering %d entries", len(kvs)))
 	var migrated int
-	for _, key := range keys {
-		v, err := src.Search(ctx, key)
+	for _, kv := range kvs {
+		exists, err := dst.Exists(ctx, kv.Key)
 		if err != nil {
-			return microerror.Maskf(err, "src storage: getting key=%s", key)
-		}
-
-		exists, err := dst.Exists(ctx, key)
-		if err != nil {
-			return microerror.Maskf(err, "dst storage: checking key=%s", key)
+			return microerror.Maskf(err, "dst storage: checking key=%s", kv.Key)
 		}
 
 		if exists {
 			continue
 		}
 
-		err = dst.Put(ctx, key, v)
+		err = dst.Put(ctx, kv)
 		if err != nil {
-			return microerror.Maskf(err, "dst storage: putting key=%s", key)
+			return microerror.Maskf(err, "dst storage: putting key=%s", kv.Key)
 		}
 		migrated++
 	}
 
-	m.logger.Log("info", fmt.Sprintf("migrated %d/%d remaining entries", migrated, len(keys)))
+	m.logger.Log("info", fmt.Sprintf("migrated %d/%d remaining entries", migrated, len(kvs)))
 	return nil
 }

--- a/retrystorage/storage.go
+++ b/retrystorage/storage.go
@@ -91,17 +91,17 @@ func New(config Config) (*Storage, error) {
 	return s, nil
 }
 
-func (s *Storage) Put(ctx context.Context, key, value string) error {
+func (s *Storage) Put(ctx context.Context, kv microstorage.KV) error {
 	b := s.newBackOffFunc()
 	op := func() error {
-		err := s.underlying.Put(ctx, key, value)
+		err := s.underlying.Put(ctx, kv)
 		if microstorage.IsInvalidKey(err) || microstorage.IsNotFound(err) {
 			return backoff.Permanent(err)
 		}
 		return err
 	}
 	notify := func(err error, delay time.Duration) {
-		s.logger.Log("warning", "retrying", "op", "put", "key", key, "delay", delay, "err", fmt.Sprintf("%#v", err))
+		s.logger.Log("warning", "retrying", "op", "put", "key", kv.Key, "delay", delay, "err", fmt.Sprintf("%#v", err))
 	}
 	err := backoff.RetryNotify(op, b, notify)
 	return microerror.Mask(err)
@@ -141,9 +141,9 @@ func (s *Storage) Exists(ctx context.Context, key string) (bool, error) {
 	return exists, microerror.Mask(err)
 }
 
-func (s *Storage) List(ctx context.Context, key string) ([]string, error) {
+func (s *Storage) List(ctx context.Context, key string) ([]microstorage.KV, error) {
 	b := s.newBackOffFunc()
-	var list []string
+	var list []microstorage.KV
 	op := func() error {
 		var err error
 		list, err = s.underlying.List(ctx, key)
@@ -159,9 +159,9 @@ func (s *Storage) List(ctx context.Context, key string) ([]string, error) {
 	return list, microerror.Mask(err)
 }
 
-func (s *Storage) Search(ctx context.Context, key string) (string, error) {
+func (s *Storage) Search(ctx context.Context, key string) (microstorage.KV, error) {
 	b := s.newBackOffFunc()
-	var value string
+	var value microstorage.KV
 	op := func() error {
 		var err error
 		value, err = s.underlying.Search(ctx, key)

--- a/storage.go
+++ b/storage.go
@@ -4,19 +4,30 @@ import (
 	"context"
 )
 
-// Storage represents the abstraction for underlying storage backends. A storage
-// implementation does not care about specific data types. All the
-// storage cares about are key-value pairs. Code making use of the storage
-// have to take care about specific types they care about them self.
+// KV is a key-value pair.
+type KV struct {
+	// Key should take a format of path separated by slashes "/". E.g.
+	// "/a/b/c". Storage implementations should validate the key before
+	// storing them. Key sanitized before inserting to the storage. I.e.
+	// leading slash can be added and trailing slash can be removed. E.g.
+	// "/a/b/c", "a/b/c/", "a/b/c/", and "/a/b/c/" represent the same key.
+	Key string
+	// Val is an arbitrary value stored under the Key.
+	Val string
+}
+
+func NewKV(key, val string) KV {
+	return KV{
+		Key: key,
+		Val: val,
+	}
+}
+
+// Storage represents the abstraction for underlying storage backends.
 type Storage interface {
 	// Put stores the given value under the given key. If the value
-	// under the key already exists Put overrides it. Keys and values might
-	// have specific schemes depending on the specific storage
-	// implementation.  E.g. an etcd storage implementation will allow keys
-	// to be defined as paths: path/to/key. Values might be JSON strings in
-	// case the storage implementation wants to store its data as JSON
-	// strings.
-	Put(ctx context.Context, key, value string) error
+	// under the key already exists Put overrides it.
+	Put(ctx context.Context, kv KV) error
 	// Delete removes the value stored under the given key.
 	Delete(ctx context.Context, key string) error
 	// Exists checks if a value under the given key exists or not.
@@ -24,7 +35,7 @@ type Storage interface {
 	// List does a lookup for all keys stored under the key, and returns the
 	// relative key path, if any.
 	// E.g: listing /foo/, with the key /foo/bar, returns bar.
-	List(ctx context.Context, key string) ([]string, error)
+	List(ctx context.Context, key string) ([]KV, error)
 	// Search does a lookup for the value stored under key and returns it, if any.
-	Search(ctx context.Context, key string) (string, error)
+	Search(ctx context.Context, key string) (KV, error)
 }

--- a/storagetest/storagetest.go
+++ b/storagetest/storagetest.go
@@ -36,35 +36,36 @@ func testBasicCRUD(t *testing.T, storage microstorage.Storage) {
 	)
 
 	for _, key := range validKeyVariations(baseKey) {
-		ok, err := storage.Exists(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.False(t, ok, "%s: key=%s", name, key)
+		kv := microstorage.NewKV(key, value)
 
-		v, err := storage.Search(ctx, key)
-		require.NotNil(t, err, "%s: key=%s", name, key)
-		require.True(t, microstorage.IsNotFound(err), "%s: key=%s expected IsNotFoundError", name, key)
+		ok, err := storage.Exists(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.False(t, ok, "%s: kv=%#v", name, kv)
 
-		err = storage.Put(ctx, key, value)
-		require.NoError(t, err, "%s: key=%s", name, key)
+		_, err = storage.Search(ctx, kv.Key)
+		require.NotNil(t, err, "%s: kv=%#v", name, kv)
+		require.True(t, microstorage.IsNotFound(err), "%s: key=%s expected IsNotFoundError", name, kv.Key)
 
-		ok, err = storage.Exists(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.True(t, ok, "%s: key=%s", name, key)
+		err = storage.Put(ctx, kv)
 
-		v, err = storage.Search(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.Equal(t, value, v, "%s: key=%s", name, key)
+		ok, err = storage.Exists(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.True(t, ok, "%s: kv=%#v", name, kv)
+
+		gotKV, err := storage.Search(ctx, key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.Equal(t, sanitize(kv), gotKV, "%s: kv=%#v", name, kv)
 
 		err = storage.Delete(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
 
 		ok, err = storage.Exists(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.False(t, ok, "%s: key=%s", name, key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.False(t, ok, "%s: kv=%#v", name, kv)
 
-		v, err = storage.Search(ctx, key)
-		require.NotNil(t, err, "%s: key=%s", name, key)
-		require.True(t, microstorage.IsNotFound(err), "%s: key=%s expected IsNotFoundError", name, key)
+		_, err = storage.Search(ctx, key)
+		require.NotNil(t, err, "%s: kv=%#v", name, kv)
+		require.True(t, microstorage.IsNotFound(err), "%s: key=%s expected IsNotFoundError", name, kv.Key)
 	}
 }
 
@@ -80,36 +81,39 @@ func testPutIdempotent(t *testing.T, storage microstorage.Storage) {
 	)
 
 	for _, key := range validKeyVariations(baseKey) {
-		ok, err := storage.Exists(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.False(t, ok, "%s: key=%s", name, key)
+		kv := microstorage.NewKV(key, value)
+
+		ok, err := storage.Exists(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.False(t, ok, "%s: kv=%#v", name, kv)
 
 		// First Put call.
 
-		err = storage.Put(ctx, key, value)
-		require.NoError(t, err, "%s: key=%s", name, key)
+		err = storage.Put(ctx, microstorage.NewKV(kv.Key, value))
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
 
-		v, err := storage.Search(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.Equal(t, value, v, "%s: key=%s", name, key)
+		gotKV, err := storage.Search(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.Equal(t, sanitize(kv), gotKV, "%s: kv=%#v", name, kv)
 
 		// Second Put call with the same value.
 
-		err = storage.Put(ctx, key, value)
-		require.NoError(t, err, "%s: key=%s", name, key)
+		err = storage.Put(ctx, kv)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
 
-		v, err = storage.Search(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.Equal(t, value, v, "%s: key=%s", name, key)
+		gotKV, err = storage.Search(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, kv)
+		require.Equal(t, sanitize(kv), gotKV, "%s: kv=%#v", name, kv)
 
 		// Third Put call with overriding value.
 
-		err = storage.Put(ctx, key, overridenValue)
-		require.NoError(t, err, "%s: key=%s", name, key)
+		overridenKV := microstorage.NewKV(kv.Key, overridenValue)
+		err = storage.Put(ctx, overridenKV)
+		require.NoError(t, err, "%s: kv=%#v", name, overridenKV)
 
-		v, err = storage.Search(ctx, key)
-		require.NoError(t, err, "%s: key=%s", name, key)
-		require.Equal(t, overridenValue, v, "%s: key=%s", name, key)
+		gotKV, err = storage.Search(ctx, kv.Key)
+		require.NoError(t, err, "%s: kv=%#v", name, overridenKV)
+		require.Equal(t, sanitize(overridenKV), gotKV, "%s: kv=%#s", name, overridenKV)
 	}
 }
 
@@ -153,11 +157,7 @@ func testInvalidKey(t *testing.T, storage microstorage.Storage) {
 	}
 
 	for _, key := range keys {
-		err := storage.Put(ctx, key, value)
-		assert.NotNil(t, err, "%s key=%s", name, key)
-		assert.True(t, microstorage.IsInvalidKey(err), "%s: expected InvalidKeyError for key=%s", name, key)
-
-		err = storage.Put(ctx, key, value)
+		err := storage.Put(ctx, microstorage.NewKV(key, value))
 		assert.NotNil(t, err, "%s key=%s", name, key)
 		assert.True(t, microstorage.IsInvalidKey(err), "%s: expected InvalidKeyError for key=%s", name, key)
 
@@ -196,22 +196,22 @@ func testList(t *testing.T, storage microstorage.Storage) {
 		key1 := path.Join(key0, "one")
 		key2 := path.Join(key0, "two")
 
-		err := storage.Put(ctx, key1, value)
+		err := storage.Put(ctx, microstorage.NewKV(key1, value))
 		assert.Nil(t, err, "%s: key=%s", name, key1)
 
-		err = storage.Put(ctx, key2, value)
+		err = storage.Put(ctx, microstorage.NewKV(key2, value))
 		assert.Nil(t, err, "%s: key=%s", name, key2)
 
-		wkeys := []string{
-			"one",
-			"two",
+		kvs := []microstorage.KV{
+			microstorage.NewKV("one", value),
+			microstorage.NewKV("two", value),
 		}
-		sort.Strings(wkeys)
+		sort.Sort(kvSlice(kvs))
 
-		keys, err := storage.List(ctx, key0)
+		gotKVs, err := storage.List(ctx, key0)
 		assert.NoError(t, err, "%s: key=%s", name, key0)
-		sort.Strings(keys)
-		assert.Equal(t, wkeys, keys, "%s: key=%s", name, key0)
+		sort.Sort(kvSlice(gotKVs))
+		assert.Equal(t, kvs, gotKVs, "%s: key=%s", name, key0)
 	}
 }
 
@@ -225,26 +225,30 @@ func testListNested(t *testing.T, storage microstorage.Storage) {
 		value   = name + "-value"
 	)
 
-	for _, key0 := range validKeyVariations(baseKey) {
-		key1 := path.Join(key0, "nested/one")
-		key2 := path.Join(key0, "nested/two")
-		key3 := path.Join(key0, "extremaly/nested/three")
+	for _, key := range validKeyVariations(baseKey) {
+		kvs := []microstorage.KV{
+			microstorage.NewKV(path.Join(key, "nested/one"), value),
+			microstorage.NewKV(path.Join(key, "nested/two"), value),
+			microstorage.NewKV(path.Join(key, "extremaly/nested/three"), value),
+		}
 
-		err := storage.Put(ctx, key1, value)
-		assert.Nil(t, err, "%s: key=%s", name, key1)
-
-		err = storage.Put(ctx, key2, value)
-		assert.Nil(t, err, "%s: key=%s", name, key2)
-
-		err = storage.Put(ctx, key3, value)
-		assert.Nil(t, err, "%s: key=%s", name, key3)
+		for _, kv := range kvs {
+			err := storage.Put(ctx, kv)
+			assert.Nil(t, err, "%s: kv=%#v", name, kv)
+		}
 
 		keyAll := "/"
-		keys, err := storage.List(ctx, keyAll)
-		assert.NoError(t, err, "%s: key=%s", name, key0)
-		assert.Contains(t, keys, sanitize(key1)[1:], "%s: key=%s", name, keyAll)
-		assert.Contains(t, keys, sanitize(key2)[1:], "%s: key=%s", name, keyAll)
-		assert.Contains(t, keys, sanitize(key3)[1:], "%s: key=%s", name, keyAll)
+		gotKVs, err := storage.List(ctx, keyAll)
+		assert.NoError(t, err, "%s: key=%#v", name, keyAll)
+
+		for _, kv := range kvs {
+			kv = sanitize(kv)
+			// Skip leading slash. This is like in file system
+			// root. When create `touch /file`, listing it `ls /`
+			// outputs `file`.
+			kv.Key = kv.Key[1:]
+			assert.Contains(t, gotKVs, kv, "%s: key=%#v", name, keyAll)
+		}
 	}
 }
 
@@ -262,10 +266,10 @@ func testListInvalid(t *testing.T, storage microstorage.Storage) {
 		key1 := path.Join(key0, "one")
 		key2 := path.Join(key0, "two")
 
-		err := storage.Put(ctx, key1, value)
+		err := storage.Put(ctx, microstorage.NewKV(key1, value))
 		assert.Nil(t, err, "%s: key=%s", name, key1)
 
-		err = storage.Put(ctx, key2, value)
+		err = storage.Put(ctx, microstorage.NewKV(key2, value))
 		assert.Nil(t, err, "%s: key=%s", name, key2)
 
 		// baseKey is key0 prefix.
@@ -304,10 +308,17 @@ func validKeyVariations(key string) []string {
 	}
 }
 
-func sanitize(key string) string {
-	k, err := microstorage.SanitizeKey(key)
+func sanitize(kv microstorage.KV) microstorage.KV {
+	k, err := microstorage.SanitizeKey(kv.Key)
 	if err != nil {
 		panic(err)
 	}
-	return k
+	kv.Key = k
+	return kv
 }
+
+type kvSlice []microstorage.KV
+
+func (p kvSlice) Len() int           { return len(p) }
+func (p kvSlice) Less(i, j int) bool { return p[i].Key < p[j].Key }
+func (p kvSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }


### PR DESCRIPTION
- Introduced KV struct.
- Opens possibility for Put to take multiple KVs.
- List returns KVs instead of keys-only. This prevents from doing another
  call when it's necessary to also know key value. Useful in userd for
  example. Also useful in data migration optimization.
- Search returns KV to be on par with List.