### PR TITLE
guarantee key format

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -54,6 +54,12 @@ func (k K) Key() string {
 	return k.key
 }
 
+// KeyNoLeadingSlash returns the actual sanitized key value with leading slash
+// stripped.
+func (k K) KeyNoLeadingSlash() string {
+	return k.key[1:]
+}
+
 // KV is an immutable key-value pair with valid key.
 type KV struct {
 	key string
@@ -104,6 +110,12 @@ func (k KV) K() K {
 // Key returns the sanitized key associated with this key-value pair.
 func (k KV) Key() string {
 	return k.key
+}
+
+// KeyNoLeadingSlash returns the actual sanitized key value with leading slash
+// stripped.
+func (k KV) KeyNoLeadingSlash() string {
+	return k.key[1:]
 }
 
 // Val returns the value associated with this key-value pair.

--- a/storage.go
+++ b/storage.go
@@ -112,8 +112,8 @@ func (k KV) Key() string {
 	return k.key
 }
 
-// KeyNoLeadingSlash returns the actual sanitized key value with leading slash
-// stripped.
+// KeyNoLeadingSlashreturns the sanitized key associated with this key-value
+// pair with leading slash stripped.
 func (k KV) KeyNoLeadingSlash() string {
 	return k.key[1:]
 }

--- a/storage_test.go
+++ b/storage_test.go
@@ -37,7 +37,7 @@ func TestK_KeyNoLeadingSlash(t *testing.T) {
 		"/a/b/c/",
 	}
 	for _, key := range keys {
-		k := MustK(NewK("a/b/c/"))
+		k := MustK(NewK(key))
 		assert.Equal(t, "/a/b/c", k.Key(), "key=%s", key)
 		assert.Equal(t, "a/b/c", k.KeyNoLeadingSlash(), "key=%s", key)
 	}
@@ -74,7 +74,7 @@ func TestKV_KeyNoLeadingSlash(t *testing.T) {
 		"/a/b/c/",
 	}
 	for _, key := range keys {
-		kv := MustKV(NewKV("a/b/c/", "any-test-value"))
+		kv := MustKV(NewKV(key, "any-test-value"))
 		assert.Equal(t, "/a/b/c", kv.Key(), "key=%s", key)
 		assert.Equal(t, "a/b/c", kv.KeyNoLeadingSlash(), "key=%s", key)
 	}

--- a/storage_test.go
+++ b/storage_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewKInvalid(t *testing.T) {
+func TestK_NewKInvalid(t *testing.T) {
 	keys := []string{
 		"",
 		"/",
@@ -29,7 +29,21 @@ func TestNewKInvalid(t *testing.T) {
 	}
 }
 
-func TestNewKVInvalid(t *testing.T) {
+func TestK_KeyNoLeadingSlash(t *testing.T) {
+	keys := []string{
+		"a/b/c",
+		"/a/b/c",
+		"a/b/c/",
+		"/a/b/c/",
+	}
+	for _, key := range keys {
+		k := MustK(NewK("a/b/c/"))
+		assert.Equal(t, "/a/b/c", k.Key(), "key=%s", key)
+		assert.Equal(t, "a/b/c", k.KeyNoLeadingSlash(), "key=%s", key)
+	}
+}
+
+func TestKV_NewKVInvalid(t *testing.T) {
 	keys := []string{
 		"",
 		"/",
@@ -49,5 +63,19 @@ func TestNewKVInvalid(t *testing.T) {
 		_, err := NewKV(key, "test-value")
 		assert.NotNil(t, err, "key=%s", key)
 		assert.True(t, IsInvalidKey(err), "expected InvalidKeyError for key=%s", key)
+	}
+}
+
+func TestKV_KeyNoLeadingSlash(t *testing.T) {
+	keys := []string{
+		"a/b/c",
+		"/a/b/c",
+		"a/b/c/",
+		"/a/b/c/",
+	}
+	for _, key := range keys {
+		kv := MustKV(NewKV("a/b/c/", "any-test-value"))
+		assert.Equal(t, "/a/b/c", kv.Key(), "key=%s", key)
+		assert.Equal(t, "a/b/c", kv.KeyNoLeadingSlash(), "key=%s", key)
 	}
 }


### PR DESCRIPTION
Key format is locked in tests. There is also new method
KeyNoLeadingSlash added to K and KV so client code does not have to do
ugliness like k.Key()[1:] which feels like possible incompatibility
threat.