### PR TITLE
Update github.com/cenkalti/backoff dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,134 +3,179 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = ""
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  digest = "1:f619cb9b07aebe5416262cdd8b86082e8d5bdc5264cb3b615ff858df0b645f97"
   name = "github.com/cenkalti/backoff"
   packages = ["."]
-  revision = "61153c768f31ee5f130071d08fc82b85208528de"
-  version = "v1.1.0"
+  pruneopts = ""
+  revision = "2ea60e5f094469f9e65adb9cd103795b73ae743e"
+  version = "v2.0.0"
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:17a0bc4efb06b5d45fb5fe0200e3d81c29782ee471a1ba0bf237a80b81ef9cdd"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
+  pruneopts = ""
   revision = "325932fa68e70dd4464598f11e2f710ac1aaec46"
 
 [[projects]]
   branch = "master"
+  digest = "1:693dc99c348122ffd1087467934015dc862466e954f0b859b7b100a5d596097d"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
-    "loggermeta"
+    "loggermeta",
   ]
+  pruneopts = ""
   revision = "216e9191d90f55723bfc0e93801af96e6b80eb12"
 
 [[projects]]
+  digest = "1:44ec1082ba97d89ce860abcc6ee3f0cf24e658d3efb8531b0f0a52f0781e4243"
   name = "github.com/go-kit/kit"
   packages = ["log"]
+  pruneopts = ""
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
   version = "v0.6.0"
 
 [[projects]]
+  digest = "1:6a4a01d58b227c4b6b11111b9f172ec5c17682b82724e58e6daf3f19f4faccd8"
   name = "github.com/go-logfmt/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:9ca737b471693542351e112c9e86be9bf7385e42256893a09ecb2a98e2036f74"
   name = "github.com/go-stack/stack"
   packages = ["."]
+  pruneopts = ""
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:3b760d3b93f994df8eb1d9ebfad17d3e9e37edcb7f7efaa15b427c0d7a64f4e4"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   branch = "master"
+  digest = "1:6a3c12156fd310ad95e3fe38070b1bf74e123552e374f1a57a188682a96d168e"
   name = "github.com/juju/errgo"
   packages = ["."]
+  pruneopts = ""
   revision = "08cceb5d0b5331634b9826762a8fd53b29b86ad8"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ed9eeebdf24aadfbca57eb50e6455bd1d2474525e0f0d4454de8c8e9bc7ee9a"
   name = "github.com/kr/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
+  digest = "1:4c23ced97a470b17d9ffd788310502a077b9c1f60221a85563e49696276b4147"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = ""
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:5e9a29677a616360bd6b9852dabff374e5f1bed83853de18d14ff051d54ad191"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
+  pruneopts = ""
   revision = "f02bfc3484a6b03d1fc00d72d86add103ef9567b"
 
 [[projects]]
   branch = "master"
+  digest = "1:60aca47f4eeeb972f1b9da7e7db51dee15ff6c59f7b401c1588b8e6771ba15ef"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = ""
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:acf9415ef3a5f298495b0e1aa4d0e18f571a3c845872944e6c52777496819b21"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = ""
   revision = "89604d197083d4781071d3c65855d24ecfb0a563"
 
 [[projects]]
   branch = "master"
+  digest = "1:f0857d075687b4ddebb10c8403d5fec9f093f7208b34ed5b6f3101ee2e77cec5"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = ""
   revision = "b15cd069a83443be3154b719d0cc9fe8117f09fb"
 
 [[projects]]
+  digest = "1:2d0dc026c4aef5e2f3a0e06a4dabe268b840d8f63190cf6894e02134a03f52c5"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
+  pruneopts = ""
   revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:f3ee2a699dd02cac37fbca1d028f1121ce0e48143a0f9abd293d3141dcfe6b92"
   name = "golang.org/x/net"
   packages = ["context"]
+  pruneopts = ""
   revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5fb281229bbcad3d2fd51775ee290c238c5dcb4b68c3064f4ead57eb9309501a"
+  input-imports = [
+    "github.com/cenkalti/backoff",
+    "github.com/giantswarm/microerror",
+    "github.com/giantswarm/micrologger",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@
 
 [[constraint]]
   name = "github.com/cenkalti/backoff"
-  version = "1.1.0"
+  version = "=2.0.0"
 
 [[constraint]]
   branch = "master"
@@ -38,4 +38,4 @@
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.0"
+  version = "=1.2.0"

--- a/vendor/github.com/cenkalti/backoff/.travis.yml
+++ b/vendor/github.com/cenkalti/backoff/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.3.3
+  - 1.x
   - tip
 before_install:
   - go get github.com/mattn/goveralls

--- a/vendor/github.com/cenkalti/backoff/backoff.go
+++ b/vendor/github.com/cenkalti/backoff/backoff.go
@@ -15,7 +15,7 @@ import "time"
 // BackOff is a backoff policy for retrying an operation.
 type BackOff interface {
 	// NextBackOff returns the duration to wait before retrying the operation,
-	// or backoff.Stop to indicate that no more retries should be made.
+	// or backoff. Stop to indicate that no more retries should be made.
 	//
 	// Example usage:
 	//

--- a/vendor/github.com/cenkalti/backoff/exponential.go
+++ b/vendor/github.com/cenkalti/backoff/exponential.go
@@ -127,7 +127,9 @@ func (b *ExponentialBackOff) NextBackOff() time.Duration {
 // GetElapsedTime returns the elapsed time since an ExponentialBackOff instance
 // is created and is reset when Reset() is called.
 //
-// The elapsed time is computed using time.Now().UnixNano().
+// The elapsed time is computed using time.Now().UnixNano(). It is
+// safe to call even while the backoff policy is used by a running
+// ticker.
 func (b *ExponentialBackOff) GetElapsedTime() time.Duration {
 	return b.Clock.Now().Sub(b.startTime)
 }

--- a/vendor/github.com/cenkalti/backoff/ticker.go
+++ b/vendor/github.com/cenkalti/backoff/ticker.go
@@ -18,9 +18,12 @@ type Ticker struct {
 	stopOnce sync.Once
 }
 
-// NewTicker returns a new Ticker containing a channel that will send the time at times
-// specified by the BackOff argument. Ticker is guaranteed to tick at least once.
-// The channel is closed when Stop method is called or BackOff stops.
+// NewTicker returns a new Ticker containing a channel that will send
+// the time at times specified by the BackOff argument. Ticker is
+// guaranteed to tick at least once.  The channel is closed when Stop
+// method is called or BackOff stops. It is not safe to manipulate the
+// provided backoff policy (notably calling NextBackOff or Reset)
+// while the ticker is running.
 func NewTicker(b BackOff) *Ticker {
 	c := make(chan time.Time)
 	t := &Ticker{
@@ -29,6 +32,7 @@ func NewTicker(b BackOff) *Ticker {
 		b:    ensureContext(b),
 		stop: make(chan struct{}),
 	}
+	t.b.Reset()
 	go t.run()
 	runtime.SetFinalizer(t, (*Ticker).Stop)
 	return t
@@ -42,7 +46,6 @@ func (t *Ticker) Stop() {
 func (t *Ticker) run() {
 	c := t.c
 	defer close(c)
-	t.b.Reset()
 
 	// Ticker is guaranteed to tick at least once.
 	afterC := t.send(time.Now())

--- a/vendor/github.com/cenkalti/backoff/ticker_test.go
+++ b/vendor/github.com/cenkalti/backoff/ticker_test.go
@@ -30,6 +30,10 @@ func TestTicker(t *testing.T) {
 
 	b := NewExponentialBackOff()
 	ticker := NewTicker(b)
+	elapsed := b.GetElapsedTime()
+	if elapsed > time.Second {
+		t.Errorf("elapsed time too large: %v", elapsed)
+	}
 
 	var err error
 	for _ = range ticker.C {

--- a/vendor/github.com/cenkalti/backoff/tries.go
+++ b/vendor/github.com/cenkalti/backoff/tries.go
@@ -3,13 +3,13 @@ package backoff
 import "time"
 
 /*
-WithMaxTries creates a wrapper around another BackOff, which will
+WithMaxRetries creates a wrapper around another BackOff, which will
 return Stop if NextBackOff() has been called too many times since
 the last time Reset() was called
 
 Note: Implementation is not thread-safe.
 */
-func WithMaxTries(b BackOff, max uint64) BackOff {
+func WithMaxRetries(b BackOff, max uint64) BackOff {
 	return &backOffTries{delegate: b, maxTries: max}
 }
 

--- a/vendor/github.com/cenkalti/backoff/tries_test.go
+++ b/vendor/github.com/cenkalti/backoff/tries_test.go
@@ -9,7 +9,7 @@ import (
 func TestMaxTriesHappy(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	max := 17 + r.Intn(13)
-	bo := WithMaxTries(&ZeroBackOff{}, uint64(max))
+	bo := WithMaxRetries(&ZeroBackOff{}, uint64(max))
 
 	// Load up the tries count, but reset should clear the record
 	for ix := 0; ix < max/2; ix++ {
@@ -45,7 +45,7 @@ func TestMaxTriesHappy(t *testing.T) {
 
 func TestMaxTriesZero(t *testing.T) {
 	// It might not make sense, but its okay to send a zero
-	bo := WithMaxTries(&ZeroBackOff{}, uint64(0))
+	bo := WithMaxRetries(&ZeroBackOff{}, uint64(0))
 	for ix := 0; ix < 11; ix++ {
 		d := bo.NextBackOff()
 		if d == Stop {


### PR DESCRIPTION
github.com/giantswarm/backoff uses v2.0.0 of cenkalti/backoff. Here it
was pinned to 1.x.x. Upgrading it to be compatible (as
giantswarm/backoff is used in many projects).

While there, also fixed testify version pinning.