### PR TITLE
Pin dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,16 +34,15 @@
   revision = "4763148864dc4815b691a69b4f60b4f4a8f88dad"
 
 [[projects]]
-  branch = "master"
-  digest = "1:cbf0385ab93895081876e58911afea60304de4a1fc1edc4ebd8c490eb8f6858f"
+  digest = "1:98e9dc8d46288ca1cbcd2925710b5fc684514ddba062e109f35a40ad5e81de8f"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
   pruneopts = ""
-  revision = "cb07ec533b5032add513abb1c4a886d7a19ddc69"
+  revision = "e8fe0fa9c0097ca80d8b773e1d728843447f9233"
+  version = "v0.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:0c5d336009b1a71d70621df2ec6027158b31f0de9de9e7ff093ddb74a2078935"
+  digest = "1:4c29007df9da78d6ea19867140d9460a8b63837334911d09a7e5018b77d85aac"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
@@ -51,7 +50,8 @@
     "microloggertest",
   ]
   pruneopts = ""
-  revision = "0926d9b7c5419173936b4556411a103bdf8d5966"
+  revision = "c4d217562e3d493e3ff571707346a5a2653475cb"
+  version = "v0.1.1"
 
 [[projects]]
   digest = "1:44ec1082ba97d89ce860abcc6ee3f0cf24e658d3efb8531b0f0a52f0781e4243"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,11 +26,11 @@
   name = "github.com/giantswarm/backoff"
 
 [[constraint]]
-  branch = "master"
+  version = "~0.1.0"
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]
-  branch = "master"
+  version = "~0.1.0"
   name = "github.com/giantswarm/micrologger"
 
 [[constraint]]

--- a/vendor/github.com/giantswarm/microerror/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/microerror/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] 2020-02-03
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/microerror/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/microerror/releases/tag/v0.1.0

--- a/vendor/github.com/giantswarm/microerror/docs/pull_request_template.md
+++ b/vendor/github.com/giantswarm/microerror/docs/pull_request_template.md
@@ -1,0 +1,3 @@
+## Checklist
+
+- [ ] Update changelog in CHANGELOG.md.

--- a/vendor/github.com/giantswarm/microerror/funcs.go
+++ b/vendor/github.com/giantswarm/microerror/funcs.go
@@ -24,3 +24,20 @@ func Stack(err error) string {
 		return err.Error()
 	}
 }
+
+// Desc returns the description of a microerror.Error.
+func Desc(err error) string {
+	c := Cause(err)
+	switch c.(type) {
+	case nil:
+		return ""
+	case *Error:
+		e, ok := c.(*Error)
+		if ok {
+			return e.Desc
+		}
+		return ""
+	default:
+		return ""
+	}
+}

--- a/vendor/github.com/giantswarm/microerror/funcs_test.go
+++ b/vendor/github.com/giantswarm/microerror/funcs_test.go
@@ -49,3 +49,41 @@ func Test_Stack(t *testing.T) {
 		})
 	}
 }
+
+func Test_Desc(t *testing.T) {
+	testCases := []struct {
+		name         string
+		inputErr     error
+		expectedDesc string
+	}{
+		{
+			name:         "case 0: microerror without Desc",
+			inputErr:     Maskf(&Error{Kind: "testKind"}, "annotation"),
+			expectedDesc: "",
+		},
+		{
+			name:         "case 1: microerror with Desc",
+			inputErr:     &Error{Kind: "testKind", Desc: "test description"},
+			expectedDesc: "test description",
+		},
+		{
+			name:         "case 2: external error",
+			inputErr:     errors.New("external error"),
+			expectedDesc: "",
+		},
+		{
+			name:         "case 3: nil",
+			inputErr:     nil,
+			expectedDesc: "",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			desc := Desc(tc.inputErr)
+			if desc != tc.expectedDesc {
+				t.Fatalf("desc = %q, expected %q", desc, tc.expectedDesc)
+			}
+		})
+	}
+}

--- a/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] 2020-03-04
+
+### Changed
+
+- Updated microerror to `v0.1.0.
+
+## [0.1.0] 2020-02-13
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/micrologger/compare/v0.1.0...HEAD
+[0.1.1]: https://github.com/giantswarm/micrologger/releases/tag/v0.1.1
+[0.1.0]: https://github.com/giantswarm/micrologger/releases/tag/v0.1.0

--- a/vendor/github.com/giantswarm/micrologger/Gopkg.lock
+++ b/vendor/github.com/giantswarm/micrologger/Gopkg.lock
@@ -2,44 +2,75 @@
 
 
 [[projects]]
-  branch = "master"
+  digest = "1:98e9dc8d46288ca1cbcd2925710b5fc684514ddba062e109f35a40ad5e81de8f"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
-  revision = "a8d5d4f526c526b4b773062958847fe7e0b7f449"
+  pruneopts = ""
+  revision = "e8fe0fa9c0097ca80d8b773e1d728843447f9233"
+  version = "v0.1.0"
 
 [[projects]]
+  digest = "1:44ec1082ba97d89ce860abcc6ee3f0cf24e658d3efb8531b0f0a52f0781e4243"
   name = "github.com/go-kit/kit"
   packages = ["log"]
+  pruneopts = ""
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
   version = "v0.6.0"
 
 [[projects]]
+  digest = "1:6a4a01d58b227c4b6b11111b9f172ec5c17682b82724e58e6daf3f19f4faccd8"
   name = "github.com/go-logfmt/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:9ca737b471693542351e112c9e86be9bf7385e42256893a09ecb2a98e2036f74"
   name = "github.com/go-stack/stack"
   packages = ["."]
+  pruneopts = ""
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
 
 [[projects]]
+  digest = "1:9fcb267c272bc5054564b392e3ff7e65e35400fd9914afb1d169f92b95e7dbc9"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/flags",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = ""
+  revision = "2d0692c2e9617365a95b295612ac0d4415ba4627"
+  version = "v0.3.1"
+
+[[projects]]
   branch = "master"
+  digest = "1:6a3c12156fd310ad95e3fe38070b1bf74e123552e374f1a57a188682a96d168e"
   name = "github.com/juju/errgo"
   packages = ["."]
+  pruneopts = ""
   revision = "08cceb5d0b5331634b9826762a8fd53b29b86ad8"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ed9eeebdf24aadfbca57eb50e6455bd1d2474525e0f0d4454de8c8e9bc7ee9a"
   name = "github.com/kr/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2adbe8d5ab3a48cdea1da27b9657857aa30d8758cead74b25c92eaa5be867f09"
+  input-imports = [
+    "github.com/giantswarm/microerror",
+    "github.com/go-kit/kit/log",
+    "github.com/go-stack/stack",
+    "github.com/google/go-cmp/cmp",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/giantswarm/micrologger/Gopkg.toml
+++ b/vendor/github.com/giantswarm/micrologger/Gopkg.toml
@@ -22,7 +22,7 @@
 
 
 [[constraint]]
-  branch = "master"
+  version = "~0.1.0"
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]
@@ -32,3 +32,7 @@
 [[constraint]]
   name = "github.com/go-stack/stack"
   version = "1.7.0"
+
+[[constraint]]
+  name = "github.com/google/go-cmp"
+  version = "0.3.1"

--- a/vendor/github.com/giantswarm/micrologger/docs/pull_request_template.md
+++ b/vendor/github.com/giantswarm/micrologger/docs/pull_request_template.md
@@ -1,0 +1,3 @@
+## Checklist
+
+- [ ] Update changelog in CHANGELOG.md.

--- a/vendor/github.com/giantswarm/micrologger/logger_test.go
+++ b/vendor/github.com/giantswarm/micrologger/logger_test.go
@@ -4,163 +4,161 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
 	"testing"
+	"unicode"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/giantswarm/micrologger/loggermeta"
 )
 
-func Test_Logger_LogWithCtx(t *testing.T) {
-	var err error
+var update = flag.Bool("update", false, "update .golden files")
 
-	out := new(bytes.Buffer)
-
-	var log Logger
-	{
-		c := Config{
-			IOWriter: out,
-		}
-		log, err = New(c)
-		if err != nil {
-			t.Fatalf("setting up logger: %#v", err)
-		}
+// Test_MicroLogger tests MicroLogger output.
+//
+// It uses golden file as reference and when changes to template are
+// intentional, they can be updated by providing -update flag for go test.
+//
+//	go test . -run Test_MicroLogger -update
+//
+func Test_MicroLogger(t *testing.T) {
+	testCases := []struct {
+		name              string
+		inputCtxKeyValues map[string]string
+		inputLogKeyVals   []interface{}
+		inputWithKeyVals  []interface{}
+	}{
+		{
+			name:              "case 0: simple call with a key and a value",
+			inputCtxKeyValues: map[string]string{},
+			inputLogKeyVals: []interface{}{
+				"foo", "bar",
+			},
+			inputWithKeyVals: []interface{}{},
+		},
+		{
+			name: "case 1: call with contextual value",
+			inputCtxKeyValues: map[string]string{
+				"baz": "zap",
+			},
+			inputLogKeyVals: []interface{}{
+				"foo", "bar",
+			},
+			inputWithKeyVals: []interface{}{},
+		},
+		{
+			name:              "case 2: call child logger created with .With",
+			inputCtxKeyValues: map[string]string{},
+			inputLogKeyVals: []interface{}{
+				"foo", "bar",
+			},
+			inputWithKeyVals: []interface{}{
+				"baz", "zap",
+			},
+		},
+		{
+			name: "case 3: uneven number of keys",
+			inputLogKeyVals: []interface{}{
+				"foo", "bar",
+				"baz",
+			},
+			inputWithKeyVals: []interface{}{
+				"zap",
+			},
+		},
+		{
+			name:              "case 4: special case for logging JSON error under stack key",
+			inputCtxKeyValues: map[string]string{},
+			inputLogKeyVals: []interface{}{
+				"foo", "bar",
+				"stack", `{"kind":"unknown","annotation":"POST https://api.github.com/repos/giantswarm/i-do-not-exist/deployments: 404 Not Found []","stack":[{"file":"/Users/kopiczko/go/src/github.com/giantswarm/opsctl/service/github/github.go","line":143},{"file":"/Users/kopiczko/go/src/github.com/giantswarm/opsctl/service/github/github.go","line":114},{"file":"/Users/kopiczko/go/src/github.com/giantswarm/opsctl/pkg/cmd/deploy/githubdeploy/deployer.go","line":41},{"file":"/Users/kopiczko/go/src/github.com/giantswarm/opsctl/command/deploy/command.go","line":226},{"file":"/Users/kopiczko/go/pkg/mod/github.com/giantswarm/backoff@v0.0.0-20190913091243-4dd491125192/retry.go","line":23},{"file":"/Users/kopiczko/go/src/github.com/giantswarm/opsctl/command/deploy/command.go","line":253}]}`,
+				"baz", "zap",
+			},
+		},
 	}
 
-	{
-		log.LogCtx(context.TODO(), "foo", "bar")
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
 
-		var got map[string]string
-		err := json.Unmarshal(out.Bytes(), &got)
-		if err != nil {
-			t.Fatalf("expected %#v got %#v", nil, err)
-		}
+			w := &bytes.Buffer{}
 
-		v1, ok := got["foo"]
-		if !ok {
-			t.Fatalf("expected %s got %s", "foo key", "nothing")
-		}
-		if v1 != "bar" {
-			t.Fatalf("expected %s got %s", "bar", v1)
-		}
-		v2, ok := got["baz"]
-		if ok {
-			t.Fatalf("expected %s got %s", "nothing", "baz key")
-		}
-		if v2 == "zap" {
-			t.Fatalf("expected %s got %s", "nothing", v2)
-		}
-	}
+			var log Logger
+			{
+				c := Config{
+					IOWriter: w,
+					TimestampFormatter: func() interface{} {
+						return "2019-10-08T20:04:13.490819+00:00"
+					},
+				}
 
-	var ctx context.Context
-	{
-		meta := loggermeta.New()
-		meta.KeyVals["baz"] = "zap"
+				log, err = New(c)
+				if err != nil {
+					t.Fatalf("err = %v, want %v", err, nil)
+				}
+			}
 
-		ctx = loggermeta.NewContext(context.Background(), meta)
-	}
+			if len(tc.inputWithKeyVals) > 0 {
+				log = log.With(tc.inputWithKeyVals...)
+			}
+			if len(tc.inputCtxKeyValues) == 0 {
+				log.Log(tc.inputLogKeyVals...)
+			} else {
+				meta := loggermeta.New()
+				meta.KeyVals = tc.inputCtxKeyValues
 
-	{
-		out.Reset()
-		log.LogCtx(ctx, "foo", "bar")
+				ctx := loggermeta.NewContext(context.Background(), meta)
 
-		var got map[string]string
-		err := json.Unmarshal(out.Bytes(), &got)
-		if err != nil {
-			t.Fatalf("expected %#v got %#v", nil, err)
-		}
+				log.LogCtx(ctx, tc.inputLogKeyVals...)
+			}
 
-		v1, ok := got["foo"]
-		if !ok {
-			t.Fatalf("expected %s got %s", "foo key", "nothing")
-		}
-		if v1 != "bar" {
-			t.Fatalf("expected %s got %s", "bar", v1)
-		}
-		v2, ok := got["baz"]
-		if !ok {
-			t.Fatalf("expected %s got %s", "baz key", "nothing")
-		}
-		if v2 != "zap" {
-			t.Fatalf("expected %s got %s", "zap", v2)
-		}
+			var actual []byte
+			{
+				// Don't flush on purpose. Logs should be
+				// flushed right after they are logged.
+				wCopy := []byte(w.String())
+				w.Reset()
+				err := json.Indent(w, wCopy, "", "\t")
+				if err != nil {
+					t.Fatalf("err = %v, want %v", err, nil)
+				}
+				actual = w.Bytes()
+			}
+
+			golden := filepath.Join("testdata", normalizeToFileName(tc.name)+".golden")
+			if *update {
+				ioutil.WriteFile(golden, actual, 0644)
+			}
+
+			expected, err := ioutil.ReadFile(golden)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(actual, expected) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(actual, expected))
+			}
+		})
 	}
 }
 
-func Test_Logger_With(t *testing.T) {
-	var err error
-
-	out := new(bytes.Buffer)
-
-	var log Logger
-	{
-		c := Config{
-			IOWriter: out,
-		}
-		log, err = New(c)
-		if err != nil {
-			t.Fatalf("setting up logger: %#v", err)
-		}
-	}
-
-	var (
-		field       = "ctxField"
-		wfieldValue = "test ctx field value"
-
-		parentLog = log
-		childLog  = log.With(field, wfieldValue)
-	)
-
-	// Make sure caller (old field) and added contextual field are logged.
-	{
-		wfieldValue := "test ctx field value"
-
-		out.Reset()
-		childLog.Log("msg", "whats up bro?")
-
-		var got map[string]string
-		json.Unmarshal(out.Bytes(), &got)
-
-		// NOTE this tests a line number which may change if lines are modified in
-		// this file.
-		wcaller := "github.com/giantswarm/micrologger/logger_test.go:117"
-		caller, ok := got["caller"]
-		if !ok {
-			t.Errorf("expected caller key")
-		}
-		if caller != wcaller {
-			t.Errorf("want caller %s, got %s", wcaller, caller)
-		}
-
-		fieldValue, ok := got[field]
-		if !ok {
-			t.Errorf("want set field %s", field)
-		}
-		if fieldValue != wfieldValue {
-			t.Errorf("want fieldValue %s, got %s", wfieldValue, fieldValue)
+// normalizeToFileName converts all non-digit, non-letter runes in input string
+// to dash ('-'). Coalesces multiple dashes into one.
+func normalizeToFileName(s string) string {
+	var result []rune
+	for _, r := range []rune(s) {
+		if unicode.IsDigit(r) || unicode.IsLetter(r) {
+			result = append(result, r)
+		} else {
+			l := len(result)
+			if l > 0 && result[l-1] != '-' {
+				result = append(result, rune('-'))
+			}
 		}
 	}
-
-	// Make sure parent logger remained unchanged.
-	{
-		out.Reset()
-		parentLog.Log("msg", "how are you?")
-
-		var got map[string]string
-		json.Unmarshal(out.Bytes(), &got)
-
-		// NOTE this tests a line number which may change if lines are modified in
-		// this file.
-		wcaller := "github.com/giantswarm/micrologger/logger_test.go:145"
-		caller, ok := got["caller"]
-		if !ok {
-			t.Errorf("expected caller key")
-		}
-		if caller != wcaller {
-			t.Errorf("want caller %s, got %s", wcaller, caller)
-		}
-
-		fieldValue, ok := got[field]
-		if ok {
-			t.Errorf("want unset field %s, got %s", field, fieldValue)
-		}
-	}
+	return string(result)
 }

--- a/vendor/github.com/giantswarm/micrologger/testdata/case-0-simple-call-with-a-key-and-a-value.golden
+++ b/vendor/github.com/giantswarm/micrologger/testdata/case-0-simple-call-with-a-key-and-a-value.golden
@@ -1,0 +1,5 @@
+{
+	"caller": "github.com/giantswarm/micrologger/logger_test.go:109",
+	"foo": "bar",
+	"time": "2019-10-08T20:04:13.490819+00:00"
+}

--- a/vendor/github.com/giantswarm/micrologger/testdata/case-1-call-with-contextual-value.golden
+++ b/vendor/github.com/giantswarm/micrologger/testdata/case-1-call-with-contextual-value.golden
@@ -1,0 +1,6 @@
+{
+	"baz": "zap",
+	"caller": "github.com/giantswarm/micrologger/logger_test.go:116",
+	"foo": "bar",
+	"time": "2019-10-08T20:04:13.490819+00:00"
+}

--- a/vendor/github.com/giantswarm/micrologger/testdata/case-2-call-child-logger-created-with-With.golden
+++ b/vendor/github.com/giantswarm/micrologger/testdata/case-2-call-child-logger-created-with-With.golden
@@ -1,0 +1,6 @@
+{
+	"baz": "zap",
+	"caller": "github.com/giantswarm/micrologger/logger_test.go:109",
+	"foo": "bar",
+	"time": "2019-10-08T20:04:13.490819+00:00"
+}

--- a/vendor/github.com/giantswarm/micrologger/testdata/case-3-uneven-number-of-keys.golden
+++ b/vendor/github.com/giantswarm/micrologger/testdata/case-3-uneven-number-of-keys.golden
@@ -1,0 +1,7 @@
+{
+	"baz": "(MISSING)",
+	"caller": "github.com/giantswarm/micrologger/logger_test.go:109",
+	"foo": "bar",
+	"time": "2019-10-08T20:04:13.490819+00:00",
+	"zap": "(MISSING)"
+}

--- a/vendor/github.com/giantswarm/micrologger/testdata/case-4-special-case-for-logging-JSON-error-under-stack-key.golden
+++ b/vendor/github.com/giantswarm/micrologger/testdata/case-4-special-case-for-logging-JSON-error-under-stack-key.golden
@@ -1,0 +1,36 @@
+{
+	"baz": "zap",
+	"caller": "github.com/giantswarm/micrologger/logger_test.go:109",
+	"foo": "bar",
+	"stack": {
+		"annotation": "POST https://api.github.com/repos/giantswarm/i-do-not-exist/deployments: 404 Not Found []",
+		"kind": "unknown",
+		"stack": [
+			{
+				"file": "/Users/kopiczko/go/src/github.com/giantswarm/opsctl/service/github/github.go",
+				"line": 143
+			},
+			{
+				"file": "/Users/kopiczko/go/src/github.com/giantswarm/opsctl/service/github/github.go",
+				"line": 114
+			},
+			{
+				"file": "/Users/kopiczko/go/src/github.com/giantswarm/opsctl/pkg/cmd/deploy/githubdeploy/deployer.go",
+				"line": 41
+			},
+			{
+				"file": "/Users/kopiczko/go/src/github.com/giantswarm/opsctl/command/deploy/command.go",
+				"line": 226
+			},
+			{
+				"file": "/Users/kopiczko/go/pkg/mod/github.com/giantswarm/backoff@v0.0.0-20190913091243-4dd491125192/retry.go",
+				"line": 23
+			},
+			{
+				"file": "/Users/kopiczko/go/src/github.com/giantswarm/opsctl/command/deploy/command.go",
+				"line": 253
+			}
+		]
+	},
+	"time": "2019-10-08T20:04:13.490819+00:00"
+}


### PR DESCRIPTION
We need to pin the microerror and micrologger dependencies to the v0.1.0 version to avoid getting breaking changes.

